### PR TITLE
Add documentation on query simplification

### DIFF
--- a/content/doc/reference.md
+++ b/content/doc/reference.md
@@ -236,7 +236,7 @@ Width and height of the tile (Default: 4096. Grid default size is 256)
 
 `simplify`: true | false
 
-Simplify geometry (lines and polygons).
+Simplify geometry (lines and polygons). Can be overridden in a layer's query configuration.
 
 Supported for PostGIS layer only.
 
@@ -282,6 +282,13 @@ Minimal zoom level for using this query.
 `maxzoom`: integer
 
 Maximal zoom level for using this query.
+
+`simplify`: true | false
+
+Simplify geometry (lines and polygons). Overrides layer simplification, if set.
+
+Supported for PostGIS layer only.
+
 
 `sql`: string
   


### PR DESCRIPTION
This is a small change to document the change in https://github.com/t-rex-tileserver/t-rex/commit/652f226355633bb912aef10dac2fcd10d2dd89e8 that allows line/polygon simplification to be set on a query as well as a layer.


